### PR TITLE
Google Glass and Pixel 3XL Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,18 +64,20 @@ captures/
 
 # IntelliJ
 *.iml
-.idea/workspace.xml
-.idea/misc.xml
-.idea/tasks.xml
-.idea/gradle.xml
-.idea/assetWizardSettings.xml
-.idea/dictionaries
-.idea/libraries
+**/.idea/workspace.xml
+**/.idea/misc.xml
+**/.idea/tasks.xml
+**/.idea/gradle.xml
+**/.idea/assetWizardSettings.xml
+**/.idea/dictionaries
+**/.idea/libraries
 # Android Studio 3 in .gitignore file.
-.idea/caches
-.idea/modules.xml
+**/.idea/caches
+**/.idea/modules.xml
 # Comment next line if keeping position of elements in Navigation Editor is relevant for you
-.idea/navEditor.xml
+**/.idea/navEditor.xml
+**/.idea/.gitignore
+**/.idea/kotlinc.xml
 
 # Keystore files
 # Uncomment the following lines if you do not want to check your keystore files in.

--- a/android_smart_glasses/main/app/build.gradle
+++ b/android_smart_glasses/main/app/build.gradle
@@ -16,7 +16,7 @@ android {
 
     defaultConfig {
         applicationId "com.wearableintelligencesystem.androidsmartglasses"
-        minSdkVersion 22
+        minSdkVersion 19
         targetSdkVersion 22
         versionCode 1
         versionName "1.0"

--- a/android_smart_glasses/main/app/src/main/AndroidManifest.xml
+++ b/android_smart_glasses/main/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
-
+    <uses-permission android:name="com.google.android.glass.permission.DEVELOPMENT" />
 
     <application
         android:allowBackup="true"
@@ -25,17 +25,24 @@
         android:roundIcon="@mipmap/wis_launcher"
         android:supportsRtl="true"
         android:theme="@style/Theme.WearableAiDisplayMoverio">
-        <activity android:name="com.wearableintelligencesystem.androidsmartglasses.MainActivity">
+        <activity
+            android:name="com.wearableintelligencesystem.androidsmartglasses.MainActivity"
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+                <action android:name="com.google.android.glass.action.VOICE_TRIGGER" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <meta-data
+                android:name="com.google.android.glass.VoiceTrigger"
+                android:resource="@xml/voice_trigger_start" />
         </activity>
+
         <service
             android:name="com.wearableintelligencesystem.androidsmartglasses.WearableAiService"
-            android:label="CameraService" >
-        </service>
+            android:label="CameraService" />
         <service android:name="com.wearableintelligencesystem.androidsmartglasses.sensors.MuseService" android:enabled="true"/>
 
         <service android:name="com.wearableintelligencesystem.androidsmartglasses.archive.AudioService" android:enabled="true" android:exported="true"></service>

--- a/android_smart_glasses/main/app/src/main/java/com/wearableintelligencesystem/androidsmartglasses/MainActivity.java
+++ b/android_smart_glasses/main/app/src/main/java/com/wearableintelligencesystem/androidsmartglasses/MainActivity.java
@@ -226,8 +226,9 @@ public class MainActivity extends AppCompatActivity {
             return;
         }
         //wifiConnected = WifiUtils.checkWifiOnAndConnected(this); //check wifi status - don't need now that we have listener in service
-        Drawable wifiOnDrawable = this.getDrawable(R.drawable.ic_wifi_on);
-        Drawable wifiOffDrawable = this.getDrawable(R.drawable.ic_wifi_off);
+        Drawable wifiOnDrawable = this.getDrawableForAnyAPI(R.drawable.ic_wifi_on);
+        Drawable wifiOffDrawable = this.getDrawableForAnyAPI(R.drawable.ic_wifi_off);
+
         if (wifiConnected) {
             mWifiStatusImageView.setImageDrawable(wifiOnDrawable);
         } else {
@@ -240,8 +241,8 @@ public class MainActivity extends AppCompatActivity {
         if (mPhoneStatusImageView == null){
             return;
         }
-        Drawable phoneOnDrawable = this.getDrawable(R.drawable.ic_phone_connected);
-        Drawable phoneOffDrawable = this.getDrawable(R.drawable.ic_phone_disconnected);
+        Drawable phoneOnDrawable = this.getDrawableForAnyAPI(R.drawable.ic_phone_connected);
+        Drawable phoneOffDrawable = this.getDrawableForAnyAPI(R.drawable.ic_phone_disconnected);
         if (phoneConnected) {
             mPhoneStatusImageView.setImageDrawable(phoneOnDrawable);
         } else {
@@ -255,10 +256,10 @@ public class MainActivity extends AppCompatActivity {
         if (mBatteryStatusImageView == null){
             return;
         }
-        Drawable batteryFullDrawable = this.getDrawable(R.drawable.ic_full_battery);
-        Drawable batteryFullChargingDrawable = this.getDrawable(R.drawable.ic_full_battery_charging);
-        Drawable batteryLowDrawable = this.getDrawable(R.drawable.ic_low_battery);
-        Drawable batteryLowChargingDrawable = this.getDrawable(R.drawable.ic_low_battery_charging);
+        Drawable batteryFullDrawable = this.getDrawableForAnyAPI(R.drawable.ic_full_battery);
+        Drawable batteryFullChargingDrawable = this.getDrawableForAnyAPI(R.drawable.ic_full_battery_charging);
+        Drawable batteryLowDrawable = this.getDrawableForAnyAPI(R.drawable.ic_low_battery);
+        Drawable batteryLowChargingDrawable = this.getDrawableForAnyAPI(R.drawable.ic_low_battery_charging);
         if (batteryFull) {
             if (batteryCharging) {
                 mBatteryStatusImageView.setImageDrawable(batteryFullChargingDrawable);
@@ -363,6 +364,14 @@ public class MainActivity extends AppCompatActivity {
 //                setupLlcUi();
 //            }
 //        }, show_time);
+    }
+
+    private Drawable getDrawableForAnyAPI(int id) {
+        if(android.os.Build.VERSION.SDK_INT >= 21) {
+            return this.getDrawable(id);
+        } else {
+            return this.getResources().getDrawable(id);
+        }
     }
 
     //generic way to set the current enumerated list of strings and display them, scrollably, on the main UI

--- a/android_smart_glasses/main/app/src/main/res/xml/voice_trigger_start.xml
+++ b/android_smart_glasses/main/app/src/main/res/xml/voice_trigger_start.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<trigger keyword="@string/app_name" />

--- a/android_smart_phone/main/app/src/main/java/com/wearableintelligencesystem/androidsmartphone/utils/NetworkUtils.java
+++ b/android_smart_phone/main/app/src/main/java/com/wearableintelligencesystem/androidsmartphone/utils/NetworkUtils.java
@@ -88,29 +88,7 @@ public class NetworkUtils {
 
     public static boolean isHotspotOn(Context context){
         WifiManager wifi = (WifiManager) context.getSystemService(Context.WIFI_SERVICE);
-        Method[] wmMethods = wifi.getClass().getDeclaredMethods();
-        for (Method method: wmMethods) {
-            if (method.getName().equals("isWifiApEnabled")) {
-
-                try {
-                    if ((Boolean) method.invoke(wifi)) {
-//                        isInetConnOn = true;
-//                        iNetMode = 2;
-                        return true;
-                    } else {
-                        return false;
-                    }
-                } catch (IllegalArgumentException e) {
-                    e.printStackTrace();
-                } catch (IllegalAccessException e) {
-                    e.printStackTrace();
-                } catch (InvocationTargetException e) {
-                    e.printStackTrace();
-                }
-
-            }
-        }
-        return false;
+        return wifi.isWifiEnabled();
     }
 
     public static InetAddress getIpAddress() {


### PR DESCRIPTION
These are the changes necessary to get things running on my particular setup. I tried to keep the tweaks fairly minimal, the primary goal to just get things up and running.

Google Glass
============

Google Glass' XE24 update (their final update) uses API 19, so I had to backport the `minSdkVersion` and make some minor tweaks to call `getDrawable` through the resource instead of directly.

Additionally, to navigate to the app, a glass specific intent-filter action had to be added. I believe this should just be ignored in other contexts, but somebody with a different pair of glasses will need to test this.

Pixel 3XL (Android 12)
======================

I'm uncertain what the original intent behind the code was in `isHotspotOn`, but `getDeclaredMethods()` caused the app to crash when running on my phone. Calling the method directly, though, seemed to work fine, so I just shifted it to the more direct approach. It seemed like primarily it was just calling `isWifiApEnabled`, but maybe there are important use cases I'm bypassing with this approach.